### PR TITLE
Pagination via query parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ ENV/
 .DS_Store
 .vscode
 .pdbrc.py
+etl/

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Server available at [http://0.0.0.0:7000/](http://0.0.0.0:7000/)
   * Remove database from request before sending response
 * Migrations with [Alembic](http://alembic.zzzcomputing.com/en/latest/)
 
-### Serialization
+### Serialization / Deserialization
 
 * [Marshmallow](https://github.com/marshmallow-code/marshmallow) to serialize objects into JSON (response) and deserialize JSON into object (request)
-* [https://github.com/sloria/webargs](webargs) to parse requests arguments (query string)
+* [webargs](https://github.com/sloria/webargs) to parse requests arguments (query string)
 * [`toasted-marshmallow`](https://github.com/lyft/toasted-marshmallow) has 10x performance, investigate

--- a/README.md
+++ b/README.md
@@ -55,14 +55,15 @@ Server available at [http://0.0.0.0:7000/](http://0.0.0.0:7000/)
 * [apispec](https://github.com/marshmallow-code/apispec) + [falcon-apispec](https://github.com/alysivji/falcon-apispec) to generate OpenAPI (aka Swagger) specification
 * Serve documentation with [falcon-swagger-ui](https://github.com/rdidyk/falcon-swagger-ui). Available at [http://0.0.0.0:7000/swagger](http://localhost:7000/swagger)
 
-### Marshmallow
-
-* serialize objects into JSON (response) and deserialize JSON into object (request)
-* [`toasted-marshmallow`](https://github.com/lyft/toasted-marshmallow) has 10x performance, investigate
-
-### SQLAlchemy
+### ORM (SQLAlchemy)
 
 * Follow pattern described in [SQLAlchemy docs](http://docs.sqlalchemy.org/en/latest/orm/session_basics.html#when-do-i-construct-a-session-when-do-i-commit-it-and-when-do-i-close-it)
   * Load database (well, declarative base) into the request object
   * Remove database from request before sending response
 * Migrations with [Alembic](http://alembic.zzzcomputing.com/en/latest/)
+
+### Serialization
+
+* [Marshmallow](https://github.com/marshmallow-code/marshmallow) to serialize objects into JSON (response) and deserialize JSON into object (request)
+* [https://github.com/sloria/webargs](webargs) to parse requests arguments (query string)
+* [`toasted-marshmallow`](https://github.com/lyft/toasted-marshmallow) has 10x performance, investigate

--- a/app/apispec.py
+++ b/app/apispec.py
@@ -13,6 +13,7 @@ from .schemas import (
     MovieSchema,
     MoviePatchSchema,
     MoviePathSchema,
+    MovieQuerySchema,
     RatingSchema,
     UserSchema,
     UserPatchSchema,
@@ -24,6 +25,7 @@ spec.definition("Login", schema=LoginSchema)
 spec.definition("Movie", schema=MovieSchema)
 spec.definition("MoviePatch", schema=MoviePatchSchema)
 spec.definition("MoviePathSchema", schema=MoviePathSchema)
+spec.definition("MovieQuerySchema", schema=MovieQuerySchema)
 spec.definition("Rating", schema=RatingSchema)
 spec.definition("User", schema=UserSchema)
 spec.definition("UserPatch", schema=UserPatchSchema)

--- a/app/apispec.py
+++ b/app/apispec.py
@@ -12,18 +12,22 @@ from .schemas import (
     LoginSchema,
     MovieSchema,
     MoviePatchSchema,
+    MoviePathSchema,
     RatingSchema,
     UserSchema,
     UserPatchSchema,
+    UserPathSchema,
 )
 
 # set marshmallow schemas
 spec.definition("Login", schema=LoginSchema)
 spec.definition("Movie", schema=MovieSchema)
 spec.definition("MoviePatch", schema=MoviePatchSchema)
+spec.definition("MoviePathSchema", schema=MoviePathSchema)
 spec.definition("Rating", schema=RatingSchema)
 spec.definition("User", schema=UserSchema)
 spec.definition("UserPatch", schema=UserPatchSchema)
+spec.definition("UserPath", schema=UserPathSchema)
 
 # parse docstrings for routes
 spec.add_path(resource=login_resource)

--- a/app/resources/movies.py
+++ b/app/resources/movies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import falcon
+from sqlalchemy_wrapper import Paginator
 
 from app.models import Movie
 from app.schemas.movies import (
@@ -15,7 +16,7 @@ class MoviesResource:
     deserializers = {"post": movies_item_schema}
     serializers = {"get": movies_list_schema, "post": movies_item_schema}
 
-    def on_get(self, req: falcon.Request, resp: falcon.Response):
+    def on_get(self, req: falcon.Request, resp: falcon.Response) -> None:
         """
         ---
         summary: Get all movies in the database
@@ -35,9 +36,11 @@ class MoviesResource:
         db = req.context["db"]
 
         resp.status = falcon.HTTP_OK
-        resp._data = db.query(Movie).all()
+        all_items_query = db.query(Movie)
+        paginated_query = Paginator(all_items_query, page=1, per_page=20)
+        resp._data = paginated_query
 
-    def on_post(self, req: falcon.Request, resp: falcon.Response):
+    def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
         """
         ---
         summary: Add new movie to database
@@ -71,12 +74,15 @@ class MoviesItemResource:
     deserializers = {"patch": movies_patch_schema}
     serializers = {"get": movies_item_schema, "patch": movies_item_schema}
 
-    def on_delete(self, req: falcon.Request, resp: falcon.Response, id: int):
+    def on_delete(self, req: falcon.Request, resp: falcon.Response, id: int) -> None:
         """
         ---
         summary: Delete movie from database
         tags:
             - Movie
+        parameters:
+            - in: path
+              schema: MoviePathSchema
         produces:
             - application/json
         responses:
@@ -95,12 +101,15 @@ class MoviesItemResource:
         resp.status = falcon.HTTP_NO_CONTENT
         resp.media = {}
 
-    def on_get(self, req: falcon.Request, resp: falcon.Response, id: int):
+    def on_get(self, req: falcon.Request, resp: falcon.Response, id: int) -> None:
         """
         ---
         summary: Get movie from database
         tags:
             - Movie
+        parameters:
+            - in: path
+              schema: MoviePathSchema
         produces:
             - application/json
         responses:
@@ -118,13 +127,15 @@ class MoviesItemResource:
         resp.status = falcon.HTTP_OK
         resp._data = movie
 
-    def on_patch(self, req: falcon.Request, resp: falcon.Response, id: int):
+    def on_patch(self, req: falcon.Request, resp: falcon.Response, id: int) -> None:
         """
         ---
         summary: Update movie details in database
         tags:
             - Movie
         parameters:
+            - in: path
+              schema: MoviePathSchema
             - in: body
               schema: MoviePatchSchema
         consumes:
@@ -156,7 +167,7 @@ class MoviesBulkResource:
     deserializers = {"post": movies_list_schema}
     serializers = {"post": movies_list_schema}
 
-    def on_post(self, req: falcon.Request, resp: falcon.Response):
+    def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
         """
         ---
         summary: Add many movies to database

--- a/app/resources/users.py
+++ b/app/resources/users.py
@@ -54,6 +54,9 @@ class UsersItemResource:
         summary: Delete user from database
         tags:
             - User
+        parameters:
+            - in: path
+              schema: UserPathSchema
         produces:
             - application/json
         responses:
@@ -78,6 +81,9 @@ class UsersItemResource:
         summary: Get user from database
         tags:
             - User
+        parameters:
+            - in: path
+              schema: UserPathSchema
         produces:
             - application/json
         responses:
@@ -101,6 +107,8 @@ class UsersItemResource:
         tags:
             - User
         parameters:
+            - in: path
+              schema: UserPathSchema
             - in: body
               schema: UserPatchSchema
         consumes:

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,5 +1,5 @@
 from .common import PaginationSchema  # noqa
 from .login import LoginSchema  # noqa
-from .movies import MovieSchema, MoviePatchSchema  # noqa
+from .movies import MovieSchema, MoviePatchSchema, MoviePathSchema  # noqa
 from .ratings import RatingSchema  # noqa
-from .users import UserSchema, UserPatchSchema  # noqa
+from .users import UserSchema, UserPatchSchema, UserPathSchema  # noqa

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,5 +1,10 @@
 from .common import PaginationSchema  # noqa
 from .login import LoginSchema  # noqa
-from .movies import MovieSchema, MoviePatchSchema, MoviePathSchema  # noqa
+from .movies import (
+    MovieSchema,
+    MoviePatchSchema,
+    MoviePathSchema,
+    MovieQuerySchema,
+)  # noqa
 from .ratings import RatingSchema  # noqa
 from .users import UserSchema, UserPatchSchema, UserPathSchema  # noqa

--- a/app/schemas/movies.py
+++ b/app/schemas/movies.py
@@ -33,7 +33,16 @@ class MoviePathSchema(Schema):
     id = fields.Int()
 
 
+class MovieQuerySchema(Schema):
+    page = fields.Int(missing=1)
+    per_page = fields.Int(missing=20)
+
+    class Meta:
+        strict = True
+
+
 movies_item_schema = MovieSchema()
 movies_list_schema = MovieSchema(many=True)
 movies_patch_schema = MoviePatchSchema()
 movies_path_schema = MoviePathSchema()
+movies_query_schema = MovieQuerySchema()

--- a/app/schemas/movies.py
+++ b/app/schemas/movies.py
@@ -6,7 +6,7 @@ from app.models import Movie
 
 class MovieSchema(Schema):
     # Fields
-    id = fields.Str(dump_only=True)
+    id = fields.Int(dump_only=True)
     title = fields.Str(required=True)
     release_year = fields.Int(required=True)
     description = fields.Str(required=True)
@@ -29,6 +29,11 @@ class MoviePatchSchema(Schema):
     description = fields.Str()
 
 
+class MoviePathSchema(Schema):
+    id = fields.Int()
+
+
 movies_item_schema = MovieSchema()
 movies_list_schema = MovieSchema(many=True)
 movies_patch_schema = MoviePatchSchema()
+movies_path_schema = MoviePathSchema()

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -7,7 +7,7 @@ from app.utilities import generate_password_hash
 
 class UserSchema(Schema):
     # Fields
-    id = fields.Str(dump_only=True)
+    id = fields.Int(dump_only=True)
     email = fields.Email(required=True)
     first_name = fields.String(required=True)
     middle_name = fields.String()
@@ -36,5 +36,10 @@ class UserPatchSchema(Schema):
     # TODO allow for changing passwords (need to think about auth strategy)
 
 
+class UserPathSchema(Schema):
+    id = fields.Int()
+
+
 users_item_schema = UserSchema()
 users_patch_schema = UserPatchSchema()
+users_path_schema = UserPathSchema()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ rq==0.12.0
 rq-scheduler==0.8.3
 SQLAlchemy==1.2.10
 SQLAlchemy-Wrapper==1.9.1
+webargs==4.0.0


### PR DESCRIPTION
Leveraging [webargs](https://github.com/sloria/webargs) to read and validate query parameters. Currently paginating via `page` and `per_page` params and webargs is a bit overkill... BUT webargs is built on top of Marshmallow which means it's easy to incorporate into our API documentation via apispec.

We will take advantage of webargs features as we implement filtering, sorting, and more advanced pagination as described in [this article on REST best practices](https://www.moesif.com/blog/technical/api-design/REST-API-Design-Filtering-Sorting-and-Pagination/).

Resources
* [Generating apispec docs from path and query params](https://github.com/marshmallow-code/apispec/pull/133)