### PR TITLE
Functional tests with Tavern

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ pipeline:
       - black .
       - sleep 15
       - alembic upgrade head
-      - pytest
+      - pytest -m "api"
 services:
   db:
     image: postgres:10.3-alpine

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ pipeline:
       - black .
       - sleep 15
       - alembic upgrade head
-      - pytest -m "api"
+      - pytest -m "not api"
 services:
   db:
     image: postgres:10.3-alpine

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Movie.search("top gun", page=1, per_page=5)
   * Remove database from request before sending response
 * Migrations with [Alembic](http://alembic.zzzcomputing.com/en/latest/)
 
+### Testing
+
+* [pytest](https://docs.pytest.org/en/latest/)
+* Functional tests via [tavern](https://taverntesting.github.io/)
+  * Works locally and not in drone (currently excluded from CI check)
+  * Either write a plugin to have Tavern hit Falcon test API or use Jenkins
+
 ### Serialization / Deserialization
 
 * [Marshmallow](https://github.com/marshmallow-code/marshmallow) to serialize objects into JSON (response) and deserialize JSON into object (request)

--- a/app/apispec.py
+++ b/app/apispec.py
@@ -10,14 +10,15 @@ from .routes import (
 )
 from .schemas import (
     LoginSchema,
-    MovieSchema,
     MoviePatchSchema,
     MoviePathSchema,
     MovieQuerySchema,
+    MovieSchema,
     RatingSchema,
-    UserSchema,
+    UserExistsSchema,
     UserPatchSchema,
     UserPathSchema,
+    UserSchema,
 )
 
 # set marshmallow schemas
@@ -28,6 +29,7 @@ spec.definition("MoviePathSchema", schema=MoviePathSchema)
 spec.definition("MovieQuerySchema", schema=MovieQuerySchema)
 spec.definition("Rating", schema=RatingSchema)
 spec.definition("User", schema=UserSchema)
+spec.definition("UserExistsSchema", schema=UserExistsSchema)
 spec.definition("UserPatch", schema=UserPatchSchema)
 spec.definition("UserPath", schema=UserPathSchema)
 

--- a/app/resources/users.py
+++ b/app/resources/users.py
@@ -3,9 +3,36 @@ from __future__ import annotations
 import falcon
 
 from app.models import User
-from app.schemas.users import users_item_schema, users_patch_schema
+from app.schemas.users import users_item_schema, users_patch_schema, users_exists_schema
 from app.utilities import find_item_by_id
 from app.workflows.user import process_new_user
+
+
+class UsersExistsResource:
+    auth = {"auth_disabled": True}
+    deserializers = {"post": users_exists_schema}
+
+    def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
+        """
+        ---
+        summary: Check if email is already in database
+        tags:
+            - User
+        parameters:
+            - in: body
+              schema: UserExistsSchema
+        consumes:
+            - application/json
+        produces:
+            - application/json
+        responses:
+            201:
+                description: User exists
+            404:
+                description: User does not exist
+        """
+        resp.status = falcon.HTTP_OK
+        resp.media = {}
 
 
 class UsersResource:

--- a/app/routes.py
+++ b/app/routes.py
@@ -24,7 +24,11 @@ from .resources.movies import (
     MoviesResource,
 )  # noqa
 from .resources.ratings import RateResource  # noqa
-from .resources.users import UsersItemResource, UsersResource  # noqa
+from .resources.users import (
+    UsersExistsResource,
+    UsersItemResource,
+    UsersResource,
+)  # noqa
 
 # login resource
 login_resource = LoginResource()
@@ -45,6 +49,9 @@ rate_movie_resource = RateResource()
 api.add_route("/movies/{id:int}/rate", rate_movie_resource)
 
 # users
+users_exists_resource = UsersExistsResource()
+api.add_route("/users/exists", users_exists_resource)
+
 users_resource = UsersResource()
 api.add_route("/users", users_resource)
 

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -7,4 +7,4 @@ from .movies import (
     MovieQuerySchema,
 )  # noqa
 from .ratings import RatingSchema  # noqa
-from .users import UserSchema, UserPatchSchema, UserPathSchema  # noqa
+from .users import UserSchema, UserPatchSchema, UserPathSchema, UserExistsSchema  # noqa

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -1,8 +1,23 @@
 from marshmallow import fields, post_load, Schema, validates, ValidationError
 
+import falcon
+
 from app import db
+from app.exceptions import HTTPError
 from app.models import User
 from app.utilities import generate_password_hash
+
+
+class UserExistsSchema(Schema):
+    # Fields
+    email = fields.Email(required=True)
+
+    # Validators
+    @validates("email")
+    def validate_email(self, data):
+        email = db.query(User).filter(User.email == data).first()
+        if not email:
+            raise HTTPError(falcon.HTTP_NOT_FOUND, errors={"email": "does not exist"})
 
 
 class UserSchema(Schema):
@@ -40,6 +55,7 @@ class UserPathSchema(Schema):
     id = fields.Int()
 
 
+users_exists_schema = UserExistsSchema()
 users_item_schema = UserSchema()
 users_patch_schema = UserPatchSchema()
 users_path_schema = UserPathSchema()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       context: .
     command: ["gunicorn", "app:api", "-b", "0.0.0.0:7000", "--reload", "--timeout",  "100000"]
     environment:
+      API_URL: http://api:7000
       DATABASE_URI: postgresql://sivdev_user:sivdev_pass@db:5432/sivdev
       ELASTICSEARCH_URI: http://elasticsearch:9200
       GMAIL_ADDRESS: $GMAIL_ADDRESS

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+tavern-global-cfg=tests/functional-tests/common.yaml
+addopts=--tb=short -s -p no:logging

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,5 +6,8 @@ ipython==6.5.0
 mypy==0.620
 pdbpp==0.9.2
 pre-commit==1.10.4
-pytest==3.7.1
 pytest-cov==2.5.1
+pytest==3.7.1
+pyyaml==3.13
+requests==2.19.1
+tavern==0.18.1

--- a/tests/functional-tests/common.yaml
+++ b/tests/functional-tests/common.yaml
@@ -1,0 +1,9 @@
+name: Common test information
+description: connection information
+
+variables:
+  host: "http://api:7000"  # TODO: add functionality to pull from env
+  test_account__first_name: Aly
+  test_account__last_name: Sivji
+  test_account__email: alysivji@gmail.com
+  test_account__password: blah

--- a/tests/functional-tests/common.yaml
+++ b/tests/functional-tests/common.yaml
@@ -1,5 +1,5 @@
 name: Common test information
-description: connection information
+description: connection, variables, et al
 
 variables:
   host: "http://api:7000"  # TODO: add functionality to pull from env

--- a/tests/functional-tests/conftest.py
+++ b/tests/functional-tests/conftest.py
@@ -1,0 +1,56 @@
+from collections import namedtuple
+import os
+
+import pytest
+import requests
+import yaml
+
+
+def full_path(file):
+    script_dir = os.path.dirname(__file__)
+    return os.path.join(script_dir, file)
+
+
+AccountDetails = namedtuple("AccountDetails", ["email", "password"])
+
+
+# Configuration
+API_URL = os.getenv("API_URL", "http://api:7000")
+
+config_data = yaml.load(open(full_path("./common.yaml"), "r"))
+FIRST_NAME = config_data["variables"]["test_account__password"]
+LAST_NAME = config_data["variables"]["test_account__password"]
+EMAIL = config_data["variables"]["test_account__email"]
+PASSWORD = config_data["variables"]["test_account__password"]
+
+
+@pytest.fixture(scope="session", name="jwt")
+def login_and_create_jwt(create_account):
+    login_url = API_URL + "/login"
+    r = requests.post(
+        login_url,
+        json={"email": create_account.email, "password": create_account.password},
+    )
+    if r.status_code == 200:
+        yield r.json()["jwt"]
+
+
+@pytest.fixture(scope="session")
+def create_account():
+    test_account = AccountDetails(EMAIL, PASSWORD)
+    exists_url = API_URL + "/users/exists"
+    create_user_url = API_URL + "/users"
+
+    r = requests.post(exists_url, json={"email": EMAIL})
+    if r.status_code != 200:
+        r = requests.post(
+            create_user_url,
+            json={
+                "first_name": FIRST_NAME,
+                "last_name": LAST_NAME,
+                "email": EMAIL,
+                "password": PASSWORD,
+            },
+        )
+
+    yield test_account

--- a/tests/functional-tests/test_users_resource.tavern.yaml
+++ b/tests/functional-tests/test_users_resource.tavern.yaml
@@ -1,0 +1,65 @@
+test_name: test_create_movie_success
+
+marks:
+  - api
+  - usefixtures:
+      - jwt
+
+stages:
+  - name: create_movie
+    request:
+      url: "{host:s}/movies"
+      method: POST
+      headers:
+        authorization: "JWT {jwt}"
+      json: &sample_movie
+        title: Title Unknown
+        release_year: 1999
+        description: Things happen over a few arcs and movie ends.
+    response:
+      status_code: 201
+      body:
+        <<: *sample_movie
+        id: !anyint
+
+---
+
+test_name: test_create_movie_422_unprocessable_entity
+
+marks:
+  - api
+  - usefixtures:
+      - jwt
+
+stages:
+  - name: create_movie
+    request:
+      url: "{host:s}/movies"
+      method: POST
+      headers:
+        authorization: "JWT {jwt}"
+      json:
+        title: Title Unknown
+    response:
+      status_code: 422
+
+---
+
+test_name: test_create_movie_401_unauthorized
+
+marks:
+  - api
+  - usefixtures:
+      - jwt
+
+stages:
+  - name: create_movie
+    request:
+      url: "{host:s}/movies"
+      method: POST
+      json:
+        title: Title Unknown
+        release_year: 1999
+        description: Things happen over a few arcs and movie ends.
+    response:
+      status_code: 401


### PR DESCRIPTION
Using Tavern to write contract tests for front-end. Currently added tests for `/users` resource.

Also added an endpoint that checks to see if user email is in the database. Can feed front-end, also makes testing easier.

Right now we are excluding tavern tests from CI. Need to write a plugin like [`tavern-flask`](https://github.com/taverntesting/tavern-flask)

### Resources
- [Tavern documentation](https://taverntesting.github.io/documentation.html)